### PR TITLE
Add decoy player command

### DIFF
--- a/neoforge/src/main/java/com/mars/laserbridges/commands/DecoyCommand.java
+++ b/neoforge/src/main/java/com/mars/laserbridges/commands/DecoyCommand.java
@@ -1,0 +1,56 @@
+package com.mars.laserbridges.commands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.core.BlockPos;
+
+public class DecoyCommand {
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(
+            Commands.literal("decoy")
+                .requires(cs -> cs.hasPermission(2))
+                .executes(ctx -> {
+                    ServerPlayer player = ctx.getSource().getPlayerOrException();
+                    spawnDecoy(player);
+                    return 1;
+                })
+        );
+    }
+
+    private static void spawnDecoy(ServerPlayer player) {
+        ArmorStand stand = new ArmorStand(EntityType.ARMOR_STAND, player.serverLevel());
+        stand.setPos(player.getX(), player.getY(), player.getZ());
+        stand.setYRot(player.getYRot());
+        stand.setXRot(player.getXRot());
+        stand.setCustomName(player.getName());
+        stand.setCustomNameVisible(true);
+        stand.setInvulnerable(true);
+        stand.setNoGravity(true);
+        stand.addTag("laserbridges_decoy");
+
+        // Copy armor
+        for (EquipmentSlot slot : EquipmentSlot.values()) {
+            if (slot.isArmor()) {
+                ItemStack copy = player.getItemBySlot(slot).copy();
+                stand.setItemSlot(slot, copy);
+            }
+        }
+        // Copy helmet or leave empty
+        ItemStack head = player.getItemBySlot(EquipmentSlot.HEAD).copy();
+        stand.setItemSlot(EquipmentSlot.HEAD, head);
+
+        player.serverLevel().addFreshEntity(stand);
+
+        // make player invisible
+        player.addEffect(new MobEffectInstance(MobEffects.INVISIBILITY, 20 * 30, 0, false, false));
+    }
+}

--- a/neoforge/src/main/java/com/mars/laserbridges/events/CommandEvents.java
+++ b/neoforge/src/main/java/com/mars/laserbridges/events/CommandEvents.java
@@ -1,0 +1,17 @@
+package com.mars.laserbridges.events;
+
+import com.mars.laserbridges.commands.DecoyCommand;
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+
+@EventBusSubscriber
+public class CommandEvents {
+    @SubscribeEvent
+    public static void onRegisterCommands(RegisterCommandsEvent event) {
+        CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
+        DecoyCommand.register(dispatcher);
+    }
+}

--- a/neoforge/src/main/java/com/mars/laserbridges/events/DecoyEvents.java
+++ b/neoforge/src/main/java/com/mars/laserbridges/events/DecoyEvents.java
@@ -1,0 +1,19 @@
+package com.mars.laserbridges.events;
+
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
+
+@EventBusSubscriber
+public class DecoyEvents {
+    @SubscribeEvent
+    public static void onAttack(LivingIncomingDamageEvent event) {
+        if (event.getEntity() instanceof ArmorStand stand && stand.getTags().contains("laserbridges_decoy")) {
+            Level level = stand.level();
+            level.broadcastEntityEvent(stand, (byte)2); // hurt animation
+            event.setCanceled(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `/decoy` command that spawns an invisible decoy armor stand with the player's gear
- handle command registration via `CommandEvents`
- cancel damage against decoys to make them invulnerable

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68878d33b42883329dd562253f0e04cf