### PR TITLE
Make all blocks fall like sand

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -18,6 +18,7 @@ neoForge {
 
 dependencies {
     compileOnly group: 'org.spongepowered', name: 'mixin', version: '0.8.5'
+    annotationProcessor group: 'org.spongepowered', name: 'mixin', version: '0.8.5', classifier: 'processor'
     // fabric and neoforge both bundle mixinextras, so it is safe to use it in common
     compileOnly group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
     annotationProcessor group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'

--- a/common/src/main/java/com/mars/laserbridges/mixin/MixinBlock.java
+++ b/common/src/main/java/com/mars/laserbridges/mixin/MixinBlock.java
@@ -1,0 +1,53 @@
+package com.mars.laserbridges.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.entity.item.FallingBlockEntity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Makes every block behave like a falling block by scheduling a tick and
+ * spawning a {@link FallingBlockEntity} whenever the block is unsupported.
+ */
+@Mixin(Block.class)
+public abstract class MixinBlock {
+
+    @Inject(method = "onPlace", at = @At("TAIL"))
+    private void laserbridges$onPlace(BlockState state, Level level, BlockPos pos,
+                                     BlockState oldState, boolean notify, CallbackInfo ci) {
+        scheduleFallCheck(level, pos);
+    }
+
+    @Inject(method = "neighborChanged", at = @At("TAIL"))
+    private void laserbridges$neighborChanged(BlockState state, Level level, BlockPos pos,
+                                             Block neighbor, BlockPos fromPos, boolean notify,
+                                             CallbackInfo ci) {
+        scheduleFallCheck(level, pos);
+    }
+
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void laserbridges$tick(BlockState state, ServerLevel level, BlockPos pos,
+                                   RandomSource random, CallbackInfo ci) {
+        if (isFree(level.getBlockState(pos.below()))) {
+            FallingBlockEntity.fall(level, pos, state);
+        }
+    }
+
+    private void scheduleFallCheck(Level level, BlockPos pos) {
+        if (!level.isClientSide()) {
+            level.scheduleTick(pos, (Block)(Object)this, 2);
+        }
+    }
+
+    private boolean isFree(BlockState state) {
+        return state.isAir() || state.liquid() || state.canBeReplaced();
+    }
+}

--- a/common/src/main/resources/laserbridges.mixins.json
+++ b/common/src/main/resources/laserbridges.mixins.json
@@ -4,7 +4,9 @@
   "package": "com.mars.laserbridges.mixin",
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_18",
-  "mixins": [],
+  "mixins": [
+    "MixinBlock"
+  ],
   "client": [
     "MixinMinecraft"
   ],


### PR DESCRIPTION
## Summary
- add a mixin to schedule ticks and spawn FallingBlock entities for any unsupported block
- register the new mixin in the mod's mixin configuration
- run the Mixin annotation processor during compilation to generate the refmap

## Testing
- `./gradlew clean build`


------
https://chatgpt.com/codex/tasks/task_e_68921a358ea48332869fba15e2a5e1f7